### PR TITLE
Produce error message for invalid Elm modules

### DIFF
--- a/angularjs-ng-elm.js
+++ b/angularjs-ng-elm.js
@@ -53,10 +53,36 @@
       wrapper.appendChild(host)
       element[0].appendChild(wrapper)
       app = apps[attrs.module] = {
-        elm: diveIntoObject(window.Elm, attrs.module).init({node: host, flags: ngInterface}),
+        elm: getElmModule(window.Elm, attrs.module).init({node: host, flags: ngInterface}),
         count: 1,
         name: attrs.module,
       }
+    }
+
+    function getElmModule(elmObject, moduleName) {
+      var module = diveIntoObject(elmObject, moduleName)
+      if (!module) {
+        var availableModules = getElmModuleNames(elmObject);
+        var error = 'Could not find an Elm module named "' + moduleName +
+            '". I found these Elm modules instead: ' + availableModules.join(', ')
+        throw new Error(error)
+      }
+      return module
+    }
+
+    function getElmModuleNames(elmObject) {
+      // If you have an Elm module, the JS Elm object will represent that module as one or more objects,
+      // with one object nested into the next per dot in the module name. Each module has an init function,
+      // so whenever we find such a function, we know we have found the end of the module name.
+      return Object.keys(elmObject).map(function (moduleName) {
+        if (typeof elmObject[moduleName].init === 'function') {
+          return [moduleName]
+        } else {
+          return getElmModuleNames(elmObject[moduleName]).map(function (subModuleName) {
+            return moduleName + '.' + subModuleName
+          })
+        }
+      })
     }
 
     element.on('$destroy', function() {

--- a/angularjs-ng-elm.js
+++ b/angularjs-ng-elm.js
@@ -70,8 +70,8 @@
       return module
     }
     
-    function isValidModule(module) {
-      return typeof module.init === 'function'
+    function isValidModule(elmObject) {
+      return typeof elmObject.init === 'function'
     }
 
     function getElmModuleNames(elmObject) {

--- a/angularjs-ng-elm.js
+++ b/angularjs-ng-elm.js
@@ -61,7 +61,7 @@
 
     function getElmModule(elmObject, moduleName) {
       var module = diveIntoObject(elmObject, moduleName)
-      if (!module) {
+      if (!module || !isValidModule(module)) {
         var availableModules = getElmModuleNames(elmObject);
         var error = 'Could not find an Elm module named "' + moduleName +
             '". I found these Elm modules instead: ' + availableModules.join(', ')
@@ -69,13 +69,17 @@
       }
       return module
     }
+    
+    function isValidModule(elmObject) {
+      return typeof module.init !== 'function'
+    }
 
     function getElmModuleNames(elmObject) {
       // If you have an Elm module, the JS Elm object will represent that module as one or more objects,
       // with one object nested into the next per dot in the module name. Each module has an init function,
       // so whenever we find such a function, we know we have found the end of the module name.
       return Object.keys(elmObject).map(function (moduleName) {
-        if (typeof elmObject[moduleName].init === 'function') {
+        if (isValidModule(elmObject[moduleName])) {
           return [moduleName]
         } else {
           return getElmModuleNames(elmObject[moduleName]).map(function (subModuleName) {

--- a/angularjs-ng-elm.js
+++ b/angularjs-ng-elm.js
@@ -70,7 +70,7 @@
       return module
     }
     
-    function isValidModule(elmObject) {
+    function isValidModule(module) {
       return typeof module.init === 'function'
     }
 

--- a/angularjs-ng-elm.js
+++ b/angularjs-ng-elm.js
@@ -71,7 +71,7 @@
     }
     
     function isValidModule(elmObject) {
-      return typeof module.init !== 'function'
+      return typeof module.init === 'function'
     }
 
     function getElmModuleNames(elmObject) {


### PR DESCRIPTION
When naming an invalid Elm module, an error will now be thrown saying the module could not be found, and detailing what modules *could* be found. Also handles nested module names. Example:

    Error: Could not find an Elm module named "Hello". I found these Elm modules instead: Hello.World